### PR TITLE
Fewer vulnerability powerup

### DIFF
--- a/lib/quadquizaminos/Tetris.ex
+++ b/lib/quadquizaminos/Tetris.ex
@@ -7,7 +7,7 @@ defmodule Quadquizaminos.Tetris do
     |> Points.move_to_location(brick.location)
   end
 
-  def drop(brick, bottom, color, brick_count) do
+  def drop(brick, bottom, color, socket) do
     new_brick = Brick.down(brick)
 
     maybe_do_drop(
@@ -16,17 +16,17 @@ defmodule Quadquizaminos.Tetris do
       brick,
       new_brick,
       color,
-      brick_count
+      socket
     )
   end
 
-  def maybe_do_drop(true = _collided, bottom, old_brick, _new_block, color, brick_count) do
+  def maybe_do_drop(true = _collided, bottom, old_brick, _new_block, color, socket) do
     new_brick = Brick.new_random()
 
     points =
       old_brick
       |> prepare
-      |> Points.with_color(color, brick_count)
+      |> Points.with_color(color, socket)
 
     {count, new_bottom} =
       bottom
@@ -44,7 +44,7 @@ defmodule Quadquizaminos.Tetris do
     }
   end
 
-  def maybe_do_drop(false = _collided, bottom, _old_block, new_block, _color, _brick_count) do
+  def maybe_do_drop(false = _collided, bottom, _old_block, new_block, _color, _socket) do
     %{
       brick: new_block,
       bottom: bottom,

--- a/lib/quadquizaminos/qna.ex
+++ b/lib/quadquizaminos/qna.ex
@@ -43,6 +43,7 @@ defmodule Quadquizaminos.QnA do
       powerup: powerup(content),
       score: score(content)
     }
+    |> IO.inspect(label: "========================================")
   end
 
   defp score(content) do
@@ -68,11 +69,23 @@ defmodule Quadquizaminos.QnA do
 
     case named_captures(regex, content) do
       %{"powerup" => powerup} ->
-        powerup |> String.trim() |> String.downcase() |> String.to_atom()
+        powerup = powerup |> String.split(":") |> transform_powerup()
 
       nil ->
         nil
     end
+  end
+
+  defp transform_powerup(powerup) when is_binary(powerup) do
+    powerup |> String.trim() |> String.downcase() |> String.to_atom()
+  end
+
+  defp transform_powerup([powerup | []]) do
+    transform_powerup(powerup)
+  end
+
+  defp transform_powerup([powerup | [value]]) do
+    {transform_powerup(powerup), String.trim(value)}
   end
 
   defp answers(content, answers) do

--- a/lib/quadquizaminos/qna.ex
+++ b/lib/quadquizaminos/qna.ex
@@ -43,7 +43,6 @@ defmodule Quadquizaminos.QnA do
       powerup: powerup(content),
       score: score(content)
     }
-    |> IO.inspect(label: "========================================")
   end
 
   defp score(content) do

--- a/lib/quadquizaminos_web/live/quiz_modal_component.ex
+++ b/lib/quadquizaminos_web/live/quiz_modal_component.ex
@@ -47,13 +47,29 @@ defmodule QuadquizaminosWeb.QuizModalComponent do
   defp show_powers(assigns) do
     ~L"""
      <%= for power <- @powers do %>
-     <i class="fas <%=power_icon(power)%>" phx-click="powerup" phx-value-powerup="<%= power %>"></i>
+     <%=  display(power) %>
      <% end %>
     """
   end
 
+  def display(power) do
+    case power do
+      {power, power_tick} ->
+        ~E"""
+        <i class="fas <%=power_icon(power)%>" phx-click="powerup" phx-value-powerup="<%= power %>" phx-value-power_tick="<%= power_tick %>"></i> 
+
+        """
+
+      power ->
+        ~E"""
+        <i class="fas <%=power_icon(power)%>" phx-click="powerup" phx-value-powerup="<%= power %>"></i> 
+        """
+    end
+  end
+
   defp power_icon(power) do
     case power do
+      :fewervulnerability -> "fa-clipboard-check"
       :deleteblock -> "fa-minus-square"
       :addblock -> "fa-plus-square"
       :moveblock -> "fa-arrows-alt"
@@ -76,7 +92,6 @@ defmodule QuadquizaminosWeb.QuizModalComponent do
       :stopattack -> "fa-file-prescription"
       :winlawsuit -> "fa-balance-scale"
       :superpower -> "fa-superpowers"
-
     end
   end
 end

--- a/lib/quadquizaminos_web/live/quiz_modal_component.ex
+++ b/lib/quadquizaminos_web/live/quiz_modal_component.ex
@@ -69,7 +69,7 @@ defmodule QuadquizaminosWeb.QuizModalComponent do
 
   defp power_icon(power) do
     case power do
-      :fewervulnerability -> "fa-clipboard-check"
+      :fewervulnerability -> "fa-less-than"
       :deleteblock -> "fa-minus-square"
       :addblock -> "fa-plus-square"
       :moveblock -> "fa-arrows-alt"

--- a/lib/quadquizaminos_web/live/tetris_live.ex
+++ b/lib/quadquizaminos_web/live/tetris_live.ex
@@ -17,6 +17,7 @@ defmodule QuadquizaminosWeb.TetrisLive do
     {:ok,
      socket
      |> assign(qna: %{}, powers: [])
+     |> assign(fewer_vuln_powerup: 0)
      |> assign(category: nil, categories: init_categories())
      |> assign(block_coordinates: nil)
      |> assign(adding_block: false, moving_block: false, deleting_block: false)
@@ -27,7 +28,6 @@ defmodule QuadquizaminosWeb.TetrisLive do
      |> assign(row_count: 0)
      |> assign(correct_answers: 0)
      |> assign(hint: :intro)
-     |> assign(fewer_vuln_powerup: 0)
      |> start_game()}
   end
 
@@ -96,6 +96,8 @@ defmodule QuadquizaminosWeb.TetrisLive do
                     <p><%= @brick_count %> QuadBlocks</p>
                     <p><%= @row_count %> Rows</p>
                     <p><%= @correct_answers %> Answers</p>
+                    <%= inspect @fewer_vuln_powerup %>
+                    <%#= display_fewer_vuln_powerup(assigns) %>
                     <p>Tech Debt: <%= @gametime_counter %></p>
                     <hr>
                 </div>
@@ -943,4 +945,18 @@ defmodule QuadquizaminosWeb.TetrisLive do
   end
 
   defp moving_title(_moving_block, _block_in_bottom), do: ""
+
+  # defp display_fewer_vuln_powerup(assigns) do
+  #   IO.inspect(@fewer_vuln_powerup)
+
+  #   cond do
+  #     @fewer_vuln_powerup == 0 or is_nil(@fewer_vuln_powerup) ->
+  #       ""
+
+  #     true ->
+  #       ~L"""
+  #       <p>Fewer vuln for <%= @fewer_vuln_powerup - @gametime_counter %>powerup</p>
+  #       """
+  #   end
+  # end
 end

--- a/lib/quadquizaminos_web/live/tetris_live.ex
+++ b/lib/quadquizaminos_web/live/tetris_live.ex
@@ -97,7 +97,6 @@ defmodule QuadquizaminosWeb.TetrisLive do
                     <p><%= @row_count %> Rows</p>
                     <p><%= @correct_answers %> Answers</p>
                     <%= inspect @fewer_vuln_powerup %>
-                    <%#= display_fewer_vuln_powerup(assigns) %>
                     <p>Tech Debt: <%= @gametime_counter %></p>
                     <hr>
                 </div>
@@ -945,18 +944,4 @@ defmodule QuadquizaminosWeb.TetrisLive do
   end
 
   defp moving_title(_moving_block, _block_in_bottom), do: ""
-
-  # defp display_fewer_vuln_powerup(assigns) do
-  #   IO.inspect(@fewer_vuln_powerup)
-
-  #   cond do
-  #     @fewer_vuln_powerup == 0 or is_nil(@fewer_vuln_powerup) ->
-  #       ""
-
-  #     true ->
-  #       ~L"""
-  #       <p>Fewer vuln for <%= @fewer_vuln_powerup - @gametime_counter %>powerup</p>
-  #       """
-  #   end
-  # end
 end

--- a/lib/quadquizaminos_web/live/tetris_live.ex
+++ b/lib/quadquizaminos_web/live/tetris_live.ex
@@ -804,24 +804,35 @@ defmodule QuadquizaminosWeb.TetrisLive do
     if Enum.empty?(bottom) do
       socket
     else
-      if socket.assigns.gametime_counter < socket.assigns.fewer_vuln_power_tick do
-        socket
-      else
-        assign(socket,
-          bottom: mark_block_vulnerable(can_be_marked?, bottom),
-          fewer_vuln_power_tick:
-            if(socket.assigns.gametime_counter >= socket.assigns.fewer_vuln_power_tick,
-              do: 0,
-              else: socket.assigns.fewer_vuln_power_tick
-            ),
-          gametime_counter:
-            if(socket.assigns.gametime_counter > @bottom_vulnerability_value,
-              do: 0,
-              else: socket.assigns.gametime_counter
-            )
-        )
-      end
+      socket.assigns.gametime_counter
+      |> active_fewer_vuln_powerup?(socket.assigns.fewer_vuln_power_tick)
+      |> mark_block_vulnerable(socket, bottom, can_be_marked?)
     end
+  end
+
+  defp mark_block_vulnerable(false = _active_fewer_vuln_powerup?, socket, bottom, can_be_marked?) do
+    assign(socket,
+      bottom: mark_block_vulnerable(can_be_marked?, bottom),
+      fewer_vuln_power_tick:
+        if(socket.assigns.gametime_counter >= socket.assigns.fewer_vuln_power_tick,
+          do: 0,
+          else: socket.assigns.fewer_vuln_power_tick
+        ),
+      gametime_counter:
+        if(socket.assigns.gametime_counter > @bottom_vulnerability_value,
+          do: 0,
+          else: socket.assigns.gametime_counter
+        )
+    )
+  end
+
+  defp mark_block_vulnerable(
+         true = _active_fewer_vuln_powerup?,
+         socket,
+         _bottom,
+         _can_be_marked?
+       ) do
+    socket
   end
 
   defp mark_block_vulnerable(true = _can_be_marked?, bottom) do
@@ -836,6 +847,10 @@ defmodule QuadquizaminosWeb.TetrisLive do
   end
 
   defp mark_block_vulnerable(_, bottom), do: bottom
+
+  defp active_fewer_vuln_powerup?(gametime_counter, fewer_vuln_power_tick) do
+    gametime_counter < fewer_vuln_power_tick
+  end
 
   defp correct_answer?(%{correct: guess}, guess), do: true
   defp correct_answer?(_qna, _guess), do: false

--- a/test/quadquizaminos/qna/open_c2/001.md
+++ b/test/quadquizaminos/qna/open_c2/001.md
@@ -24,3 +24,6 @@ What does C2 stand for in OpenC2?
 - Communications & Control
 - Covert Communications
 * Command & Control
+
+## Powerup
+FewerVulnerability:100

--- a/test/quadquizaminos/qna/points_test.exs
+++ b/test/quadquizaminos/qna/points_test.exs
@@ -20,12 +20,20 @@ defmodule Quadquizaminos.PointsTest do
       points: points,
       color: color
     } do
-      actual = Points.with_color(points, color, 23)
+      socket = %{
+        assigns: %{brick_count: 23, gametime_counter: 1, fewer_vuln_powerup: 0}
+      }
+
+      actual = Points.with_color(points, color, socket)
       expected = [{2, 1, :red}, {2, 2, :red}, {2, 3, :red}, {2, 4, :red}]
 
       assert actual == expected
 
-      actual = Points.with_color(points, color, 21)
+      socket = %{
+        assigns: %{brick_count: 21, gametime_counter: 1, fewer_vuln_powerup: 0}
+      }
+
+      actual = Points.with_color(points, color, socket)
       expected = [{2, 1, :red}, {2, 2, :red}, {2, 3, :red}, {2, 4, :vuln_grey_yellow}]
 
       assert actual == expected

--- a/test/quadquizaminos/qna/points_test.exs
+++ b/test/quadquizaminos/qna/points_test.exs
@@ -38,5 +38,19 @@ defmodule Quadquizaminos.PointsTest do
 
       assert actual == expected
     end
+
+    test "vulnerability isn't added to incoming block if fewer vuln power up is triggered", %{
+      points: points,
+      color: color
+    } do
+      socket = %{
+        assigns: %{brick_count: 21, gametime_counter: 1, fewer_vuln_powerup: 100}
+      }
+
+      actual = Points.with_color(points, color, socket)
+      expected = [{2, 1, :red}, {2, 2, :red}, {2, 3, :red}, {2, 4, :red}]
+
+      assert actual == expected
+    end
   end
 end

--- a/test/quadquizaminos/qna_test.exs
+++ b/test/quadquizaminos/qna_test.exs
@@ -5,9 +5,8 @@ defmodule Quadquizaminos.QnaTest do
 
   test "answers are determined by hyphen or asterisk in newline" do
     # category with two answers
-    [category | _] = QnA.categories()
 
-    %{answers: answers} = QnA.question(category)
+    %{answers: answers} = QnA.question("open_chain_sample")
 
     assert Enum.count(answers) == 2
   end

--- a/test/quadquizaminos/tetris_test.exs
+++ b/test/quadquizaminos/tetris_test.exs
@@ -44,9 +44,12 @@ defmodule Quadquizaminos.TetrisTest do
   test "drops and merges" do
     brick = Brick.new(location: {5, 16})
     bottom = %{}
-    brick_count = 1
 
-    %{score: score, bottom: bottom} = Quadquizaminos.Tetris.drop(brick, bottom, :red, brick_count)
+    socket = %{
+      assigns: %{brick_count: 1, gametime_counter: 1, fewer_vuln_powerup: 0}
+    }
+
+    %{score: score, bottom: bottom} = Quadquizaminos.Tetris.drop(brick, bottom, :red, socket)
 
     assert Map.get(bottom, {7, 20}) == {7, 20, :red}
     assert score == 0
@@ -54,7 +57,10 @@ defmodule Quadquizaminos.TetrisTest do
 
   test "drops to bottom and compresses" do
     brick = Brick.new(location: {5, 16})
-    brick_count = 1
+
+    socket = %{
+      assigns: %{brick_count: 1, gametime_counter: 1, fewer_vuln_powerup: 0}
+    }
 
     bottom =
       for x <- 1..10, y <- 17..20, x != 7 do
@@ -62,7 +68,7 @@ defmodule Quadquizaminos.TetrisTest do
       end
       |> Map.new()
 
-    %{score: score, bottom: bottom} = Quadquizaminos.Tetris.drop(brick, bottom, :red, brick_count)
+    %{score: score, bottom: bottom} = Quadquizaminos.Tetris.drop(brick, bottom, :red, socket)
 
     assert bottom == %{}
     assert score == 1600

--- a/test/quadquizaminos_web/live/power_up_test.exs
+++ b/test/quadquizaminos_web/live/power_up_test.exs
@@ -47,6 +47,31 @@ defmodule QuadquizaminosWeb.PowerUpTest do
     refute html =~ "<i class=\"fas fa-plus-square\""
   end
 
+  describe "Fewer vulnerability" do
+    setup %{conn: conn} do
+      {view, _html} = pause_game(conn)
+
+      render_click(view, "choose_category", %{"category" => "open_c2"})
+
+      right_answer = Quadquizaminos.QnA.question("open_c2").correct
+      html = render_submit(view, "check_answer", %{"quiz" => %{"guess" => right_answer}})
+
+      [html: html, view: view]
+    end
+
+    test "powerup is shown when question with fewer vulnerability powerup is answered correctly",
+         %{html: html} do
+      assert html =~ "<i class=\"fas fa-less-than\""
+    end
+
+    test "powerup is depleted once used", %{view: view} do
+      html =
+        render_click(view, "powerup", %{"powerup" => "fewervulnerability", "power_tick" => "100"})
+
+      refute html =~ "<i class=\"fas fa-less-than\""
+    end
+  end
+
   describe "Addblock" do
     setup %{conn: conn} do
       {view, _html} = pause_game(conn)

--- a/test/quadquizaminos_web/live/vulnerability_test.exs
+++ b/test/quadquizaminos_web/live/vulnerability_test.exs
@@ -8,37 +8,34 @@ defmodule QuadquizaminosWeb.VulnerabilityTest do
   setup %{conn: conn} do
     user = %User{name: "Quiz Block ", user_id: 40_000_000}
     conn = assign(conn, :current_user, user.user_id)
-    [user: user, conn: conn]
+
+    bottom = %{
+      {1, 20} => {1, 20, :blue},
+      {1, 19} => {1, 19, :blue},
+      {1, 18} => {1, 18, :blue},
+      {1, 17} => {1, 17, :blue}
+    }
+
+    assigns = %{
+      bottom: bottom,
+      brick: Quadquizaminos.Brick.new_random(),
+      current_user: 40_000_000,
+      gametime_counter: @bottom_vulnerability_value,
+      score: 0,
+      speed: 2,
+      state: :playing,
+      tick_count: 1,
+      qna: QnA.question("open_c2"),
+      row_count: 0,
+      brick_count: 1,
+      fewer_vuln_powerup: 0,
+      hint: :intro
+    }
+
+    [user: user, conn: conn, assigns: assigns, bottom: bottom]
   end
 
   describe "Bottom Vulnerability:" do
-    setup do
-      bottom = %{
-        {1, 20} => {1, 20, :blue},
-        {1, 19} => {1, 19, :blue},
-        {1, 18} => {1, 18, :blue},
-        {1, 17} => {1, 17, :blue}
-      }
-
-      assigns = %{
-        bottom: bottom,
-        brick: Quadquizaminos.Brick.new_random(),
-        current_user: 40_000_000,
-        gametime_counter: @bottom_vulnerability_value,
-        score: 0,
-        speed: 2,
-        state: :playing,
-        tick_count: 1,
-        qna: QnA.question("open_c2"),
-        row_count: 0,
-        brick_count: 1,
-        fewer_vuln_powerup: 0,
-        hint: :intro
-      }
-
-      [assigns: assigns, bottom: bottom]
-    end
-
     test "gametime_counter increases on clock tick", %{assigns: assigns} do
       socket = clock_tick_handler(assigns)
 
@@ -149,6 +146,52 @@ defmodule QuadquizaminosWeb.VulnerabilityTest do
       # brick count is 1
       # vulnerability_new_brick_threshold: 7
       refute html =~ "vuln_grey_yellow"
+    end
+  end
+
+  describe "With Fewer vulnerability powerup:" do
+    test "bottom vulnerability isn't added for X ticks of the game clock", %{assigns: assigns} do
+      assigns = %{assigns | fewer_vuln_powerup: 100}
+
+      socket = clock_tick_handler(assigns)
+
+      refute Enum.any?(socket.assigns.bottom, fn {_point, {_x, _y, color}} ->
+               color == :vuln_grey_yellow
+             end)
+    end
+
+    test "isn't added to bottom block on any wrong answer for X ticks of the game clock", %{
+      assigns: assigns
+    } do
+      assigns = %{assigns | fewer_vuln_powerup: 100}
+      socket = %Phoenix.LiveView.Socket{assigns: assigns}
+      right_answer = Quadquizaminos.QnA.question("open_c2").correct
+
+      wrong_answer =
+        Enum.find(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"], fn guess ->
+          guess != right_answer
+        end)
+
+      {:noreply, socket} =
+        QuadquizaminosWeb.TetrisLive.handle_event(
+          "check_answer",
+          %{"quiz" => %{"guess" => wrong_answer}},
+          socket
+        )
+
+      refute Enum.any?(socket.assigns.bottom, fn {_point, {_x, _y, color}} ->
+               color == :vuln_grey_yellow
+             end)
+    end
+
+    test "fewer_vuln_powerup is depleted once X tick of the game clock is exhausted", %{
+      assigns: assigns
+    } do
+      assigns = %{assigns | fewer_vuln_powerup: 100, gametime_counter: 100}
+
+      socket = clock_tick_handler(assigns)
+
+      assert socket.assigns.fewer_vuln_powerup == 0
     end
   end
 

--- a/test/quadquizaminos_web/live/vulnerability_test.exs
+++ b/test/quadquizaminos_web/live/vulnerability_test.exs
@@ -31,7 +31,9 @@ defmodule QuadquizaminosWeb.VulnerabilityTest do
         tick_count: 1,
         qna: QnA.question("open_c2"),
         row_count: 0,
-        brick_count: 1
+        brick_count: 1,
+        fewer_vuln_powerup: 0,
+        hint: :intro
       }
 
       [assigns: assigns, bottom: bottom]


### PR DESCRIPTION
closes #212 

NB: format used for fewer vulnerability in qna markup 
```
## Powerup
FewerVulnerability:100

```

Before fewer vulnerability powerup is triggered, vulnerability is added to bottom block randomly when tech debt crosses bottom block threshold, added to incoming block when the brick count is equally divided with incoming vulnerability threshold, and added to bottom block when qna question is wrongly answered

![Peek 2021-04-09 12-38](https://user-images.githubusercontent.com/43263401/114161712-1209a000-9931-11eb-9ff5-77507e24fabf.gif)

After fewer vulnerability powerup is triggered no new vulnerability is added for X ticks(100) of the game clock.

![Peek 2021-04-09 12-53](https://user-images.githubusercontent.com/43263401/114163415-d7086c00-9932-11eb-9ebe-b97057a11951.gif)




