### PR TITLE
disable scroll on keydown

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -36,3 +36,7 @@ liveSocket.connect();
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket;
+
+window.addEventListener(
+    'keydown', function(evt) { evt.preventDefault(); }, false
+);

--- a/lib/quadquizaminos_web/live/tetris_live.ex
+++ b/lib/quadquizaminos_web/live/tetris_live.ex
@@ -202,7 +202,7 @@ defmodule QuadquizaminosWeb.TetrisLive do
       brick
       |> Brick.prepare()
       |> Points.move_to_location(brick.location)
-      |> Points.with_color(color(brick))
+      |> Points.with_color(color(brick), socket.assigns.brick_count)
 
     assign(socket, tetromino: points)
   end
@@ -397,6 +397,7 @@ defmodule QuadquizaminosWeb.TetrisLive do
       (socket.assigns.powers ++
          Powers.all_powers())
       |> Enum.sort()
+
     {:noreply, socket |> assign(powers: powers)}
   end
 
@@ -472,7 +473,6 @@ defmodule QuadquizaminosWeb.TetrisLive do
     powers = socket.assigns.powers -- [:speedup]
     speed = Speed.increase_speed(socket.assigns.speed)
     tick_count = Speed.speed_tick_count(speed)
-
 
     {:noreply,
      socket


### PR DESCRIPTION
closes #198 

NB: to scroll through the page, its only possible with a mouse. Arrow up and Arrow down are disable for scrolling through the page

![Peek 2021-04-12 16-35](https://user-images.githubusercontent.com/43263401/114403362-64ef8b80-9bad-11eb-86e1-2d2f8d86677b.gif)
