### PR TITLE
Restrict user depending on login level bug

### DIFF
--- a/lib/quadquizaminos_web/views/page_view.ex
+++ b/lib/quadquizaminos_web/views/page_view.ex
@@ -38,7 +38,7 @@ defmodule QuadquizaminosWeb.PageView do
     """
   end
 
-  defp sign_up_button("anonymous_login") do
+  defp sign_up_button(_login_level) do
     ~E"""
     <a class="button" href="<%= Routes.auth_path(QuadquizaminosWeb.Endpoint, :request, "github") %>">
          <i class="fas fa-github"></i>
@@ -53,11 +53,10 @@ defmodule QuadquizaminosWeb.PageView do
     """
   end
 
-  defp sign_up_button(_) do
-    ""
-  end
-
   defp selected_login_level do
-    Accounts.get_selected_login_level().name
+    case Accounts.get_selected_login_level() do
+      nil -> nil
+      login_level -> login_level.name
+    end
   end
 end

--- a/test/quadquizaminos_web/live/login_level_test.exs
+++ b/test/quadquizaminos_web/live/login_level_test.exs
@@ -6,6 +6,13 @@ defmodule QuadquizaminosWeb.LoginLevelTest do
   alias Quadquizaminos.Accounts.User
   alias Quadquizaminos.Test.Auth
 
+  test "all sign up button is displayed when there is login level selected", %{conn: conn} do
+    conn = get(conn, "/")
+    assert conn.resp_body =~ "Sign in with GitHub"
+    assert conn.resp_body =~ "Sign in anonymously"
+    assert conn.resp_body =~ "Sign in with Google"
+  end
+
   describe "by_config when selected:" do
     setup do
       # admin logging in

--- a/test/quadquizaminos_web/live/login_level_test.exs
+++ b/test/quadquizaminos_web/live/login_level_test.exs
@@ -6,7 +6,7 @@ defmodule QuadquizaminosWeb.LoginLevelTest do
   alias Quadquizaminos.Accounts.User
   alias Quadquizaminos.Test.Auth
 
-  test "all sign up button is displayed when there is login level selected", %{conn: conn} do
+  test "all sign up button is displayed when there is no login level selected", %{conn: conn} do
     conn = get(conn, "/")
     assert conn.resp_body =~ "Sign in with GitHub"
     assert conn.resp_body =~ "Sign in anonymously"


### PR DESCRIPTION
bug: when there is no login level selected
![image](https://user-images.githubusercontent.com/43263401/116975670-abc23400-acc8-11eb-9d21-91a24d5eb526.png)



currently , when there is no login level selected, all sign up buttons are displayed
![image](https://user-images.githubusercontent.com/43263401/116975501-6a318900-acc8-11eb-8f05-71708128136b.png)
