### PR TITLE
fix skip question bug

### DIFF
--- a/lib/quadquizaminos_web/live/quiz_modal_component.ex
+++ b/lib/quadquizaminos_web/live/quiz_modal_component.ex
@@ -50,7 +50,7 @@ defmodule QuadquizaminosWeb.QuizModalComponent do
     ~L"""
     <%= f =  form_for :quiz, "#", phx_submit: :check_answer %>
     <%= text_input f, :guess %>
-    <button class="button-outline" phx-click="skip-question" phx-value-category="bonus">Skip Question</button><br>
+    <button class="button-outline" phx-click="skip-question">Skip Question</button><br>
     <%= submit  "Continue" %>
     </form>
     """

--- a/lib/quadquizaminos_web/live/tetris_live.ex
+++ b/lib/quadquizaminos_web/live/tetris_live.ex
@@ -343,17 +343,8 @@ defmodule QuadquizaminosWeb.TetrisLive do
      )}
   end
 
-  def handle_event("skip-question", %{"category" => category}, socket) do
-    categories = socket.assigns.categories
-    question_position = categories[category]
-    categories = increment_position(categories, category, question_position)
-
-    {:noreply,
-     socket
-     |> assign(
-       category: nil,
-       categories: categories
-     )}
+  def handle_event("skip-question", _, socket) do
+    {:noreply, assign(socket, category: nil)}
   end
 
   def handle_event("unpause", _, socket) do

--- a/test/quadquizaminos/qna/bonus/001.md
+++ b/test/quadquizaminos/qna/bonus/001.md
@@ -1,0 +1,22 @@
+## Bonus Question #1
+
+To know the answer to this question requires
+watching - and listening to! -
+BSides Las Vegas Sunday 4PM Pacific (1PM Eastern)
+https://www.bsideslv.org/talks#1045530.
+
+You can watch live or watch the replay
+if after the fact.
+
+# Question:
+What is the answer to bonus question #1
+
+## Answers
+* 001
+
+## Score
+- Right:1000
+- Wrong:500
+
+## Powerup
+Superpower

--- a/test/quadquizaminos/qna/bonus/002.md
+++ b/test/quadquizaminos/qna/bonus/002.md
@@ -1,0 +1,22 @@
+## Bonus Question #2
+
+To know the answer to this question requires
+watching - and listening to! -
+BSides Las Vegas Sunday 4PM Pacific (1PM Eastern)
+https://www.bsideslv.org/talks#1045530
+
+You can watch live or watch the replay
+if after the fact.
+
+# Question:
+What is the answer to bonus question #2
+
+## Answers
+* 002
+
+## Score
+- Right:1000
+- Wrong:500
+
+## Powerup
+Superpower

--- a/test/quadquizaminos/qna/bonus/003.md
+++ b/test/quadquizaminos/qna/bonus/003.md
@@ -1,0 +1,22 @@
+## Bonus Question #3
+
+To know the answer to this question requires
+watching - and listening to! -
+BSides Las Vegas Sunday 4PM Pacific (1PM Eastern)
+https://www.bsideslv.org/talks#1045530
+
+You can watch live or watch the replay
+if after the fact.
+
+# Question:
+What is the answer to bonus question #3
+
+## Answers
+* 003
+
+## Score
+- Right:1000
+- Wrong:500
+
+## Powerup
+Superpower

--- a/test/quadquizaminos_web/live/tetris_live_test.exs
+++ b/test/quadquizaminos_web/live/tetris_live_test.exs
@@ -143,6 +143,34 @@ defmodule QuadquizaminosWeb.TetrisLiveTest do
     end
   end
 
+  describe "skip question" do
+    test "player can skip question", %{conn: conn} do
+      {view, _html} = pause_game(conn)
+      render_click(view, "choose_category", %{"category" => "bonus"})
+      html = render_click(view, "skip-question", %{})
+
+      assert html =~ "Continue</button>"
+      assert html =~ "End Game</button>"
+      assert html =~ "Bonus</button>"
+    end
+
+    test "category disappears if questions are exhausted", %{conn: conn} do
+      {view, _html} = pause_game(conn)
+
+      # bonus questions are 3, skip all
+      render_click(view, "choose_category", %{"category" => "bonus"})
+      render_click(view, "skip-question", %{})
+
+      render_click(view, "choose_category", %{"category" => "bonus"})
+      render_click(view, "skip-question", %{})
+
+      render_click(view, "choose_category", %{"category" => "bonus"})
+      html = render_click(view, "skip-question", %{})
+
+      refute html =~ "Bonus</button>"
+    end
+  end
+
   defp pause_game(conn) do
     {:ok, view, _html} = live(conn, "/tetris")
 


### PR DESCRIPTION

![Peek 2021-07-30 12-29](https://user-images.githubusercontent.com/43263401/127639709-3fae9ddd-0bf8-4793-8c9f-a439c87d0111.gif)
closes #432 

Error: 
Let's say bonus category has 3 qna(001.md, 002,md, 003.md) , when a player chooses the bonus category for the first time question 001.md is shown , if the player skips the question then reselects the bonus category question 003.md will be displayed as the next question and the bonus category button disappears .
Here is a demo of the bug:

![Peek 2021-07-30 12-27](https://user-images.githubusercontent.com/43263401/127633388-52378063-8314-4035-bd57-509d30ee3584.gif)

After fix

![Peek 2021-07-30 12-29](https://user-images.githubusercontent.com/43263401/127639709-3fae9ddd-0bf8-4793-8c9f-a439c87d0111.gif)