### PR TITLE
upgrade cyclonedx/bom version

### DIFF
--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -17,7 +17,7 @@ name: Staging Deploy
 on:
   push:
     branches:
-    - fix_npm_warning 
+    - develop
 
 env:
   PROJECT_ID: ${{ secrets.GCE_PROJECT }}

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -17,7 +17,7 @@ name: Staging Deploy
 on:
   push:
     branches:
-    - develop
+    - fix_npm_warning 
 
 env:
   PROJECT_ID: ${{ secrets.GCE_PROJECT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY courses ./courses
 COPY Makefile ./Makefile
 
 RUN npm ci --prefix ./assets
-RUN npm install -g @cyclonedx/bom@2.0.2
+RUN npm install -g @cyclonedx/bom@3.1.1
 RUN make sbom_fast
 RUN cp *bom* ./assets/static/.well-known/sbom/
 RUN npm run deploy --prefix ./assets

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ format: mix format ## Run formatting tools on the code
 .PHONY: sbom sbom_fast
 sbom: ## creates sbom for both  npm and hex dependancies
 	mix deps.get && mix sbom.cyclonedx -o elixir_bom.xml
-	cd assets/  && npm install && npm install -g @cyclonedx/bom@2.0.2 && cyclonedx-bom -o ../$(SBOM_FILE_NAME_CY).xml -a ../elixir_bom.xml && cd ..
+	cd assets/  && npm install && npm install -g @cyclonedx/bom@3.1.1 && cyclonedx-bom -o ../$(SBOM_FILE_NAME_CY).xml && cd ..
+	./cyclonedx-cli merge --input-files ./$(SBOM_FILE_NAME_CY).xml ./elixir_bom.xml --output-file $(SBOM_FILE_NAME_CY)-all.xml
 	./cyclonedx-cli convert --input-file $(SBOM_FILE_NAME_CY).xml --output-file $(SBOM_FILE_NAME_CY).json
 	./cyclonedx-cli convert --input-file $(SBOM_FILE_NAME_CY).json --output-format spdxtag --output-file $(SBOM_FILE_NAME_SPDX).spdx
 	mkdir -p assets/static/.well-known/sbom
@@ -89,7 +90,8 @@ sbom: ## creates sbom for both  npm and hex dependancies
 
 sbom_fast: ## creates sbom without dependancy instalment, assumes you have cyclonedx-bom javascript package installed globally
 	mix sbom.cyclonedx -o elixir_bom.xml
-	cd assets/ && cyclonedx-bom -o ../$(SBOM_FILE_NAME_CY).xml -a ../elixir_bom.xml && cd ..
+	cd assets/ && cyclonedx-bom -o ../$(SBOM_FILE_NAME_CY).xml && cd ..
+	./cyclonedx-cli merge --input-files ./$(SBOM_FILE_NAME_CY).xml ./elixir_bom.xml --output-file $(SBOM_FILE_NAME_CY)-all.xml
 	./cyclonedx-cli convert --input-file $(SBOM_FILE_NAME_CY).xml --output-file $(SBOM_FILE_NAME_CY).json
 	./cyclonedx-cli convert --input-file $(SBOM_FILE_NAME_CY).json --output-format spdxtag --output-file $(SBOM_FILE_NAME_SPDX).spdx
 	mkdir -p assets/static/.well-known/sbom


### PR DESCRIPTION
related to #622 
What has been done:
- Upgrade cyclonedx/bom from v2.0.2  to v3.1.1 which is the latest.
- v3.1.1 does not support `--append` option the functionality was moved to the CLI tool https://github.com/CycloneDX/cyclonedx-cli/#merge-command. 