### PR TITLE
Fix bug in courses page

### DIFF
--- a/lib/quadquizaminos_web/router.ex
+++ b/lib/quadquizaminos_web/router.ex
@@ -72,6 +72,8 @@ defmodule QuadquizaminosWeb.Router do
     live "/leaderboard", LeaderboardLive
     live "/contests", ContestsLive, :index
     live "/contest-prizes", ContestPrizes
+
+    pipe_through :authorize
     live "/courses", CourseLive
   end
 


### PR DESCRIPTION
Bug:
no function clause matching in QuadquizaminosWeb.CourseLive.mount/3
Initially, unauthorized users weren't able to access the courses page .The error was raised because courses page wasn't authorized after piping it through `tailwind_layout` .

Before fix:

![image](https://user-images.githubusercontent.com/43263401/150827774-75f0b5c9-ecf7-4a76-8f37-bf1964d37688.png)

After fix:

![image](https://user-images.githubusercontent.com/43263401/150827893-cdb7e275-4acf-49d2-ae51-63fd778b6686.png)


related #738 