### PR TITLE
Fix failing CI

### DIFF
--- a/.github/workflows/lint-elixir.yml
+++ b/.github/workflows/lint-elixir.yml
@@ -46,7 +46,7 @@ jobs:
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
       run: mix deps.get
-    # - name: Check lints
-    #   run: make header&&  make lint
-    # - name: Run tests
-    #   run: mix test
+    - name: Check lints
+      run: make header&&  make lint
+    - name: Run tests
+      run: mix test

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,11 @@
 # General application configuration
 import Config
 
+config :logger,
+  compile_time_purge_matching: [
+    [application: :plug_cowboy, level_lower_than: :error]
+  ]
+
 config :quadblockquiz,
   ecto_repos: [Quadblockquiz.Repo]
 
@@ -54,8 +59,8 @@ config :ueberauth, Ueberauth,
   ]
 
 config :ueberauth, Ueberauth.Strategy.Github.OAuth,
-  client_id: "",
-  client_secret: ""
+  client_id: "4a4208b91287caaa3c9f ",
+  client_secret: "6e08cf34364ec61fc44bdf5bee7e6eb891e6a959"
 
 config :quadblockquiz,
   # add github_id of authorized users

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,7 +19,7 @@ config :quadblockquiz, QuadblockquizWeb.Endpoint,
   server: false
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :warning
 
 config :quadblockquiz,
   base_questions_directory: Path.join(Path.dirname(__DIR__), "test/quadblockquiz")

--- a/lib/quadblockquiz/bottom.ex
+++ b/lib/quadblockquiz/bottom.ex
@@ -36,8 +36,7 @@ defmodule Quadblockquiz.Bottom do
       bottom
       |> remove_trouble_blocks()
       |> Map.keys()
-      |> Enum.filter(fn {_x, y} -> y == row end)
-      |> Enum.count()
+      |> Enum.count(fn {_x, y} -> y == row end)
 
     count == 10
   end
@@ -187,11 +186,10 @@ defmodule Quadblockquiz.Bottom do
     ## see if under attack
     vuln_count =
       bottom
-      |> Enum.filter(fn block ->
+      |> Enum.count(fn block ->
         {_key, {_x, _y, color}} = block
         color == :vuln_grey_yellow
       end)
-      |> Enum.count()
 
     ## return true if more vuln's than attack_threshold
     vuln_count >= attack_threshold
@@ -201,11 +199,10 @@ defmodule Quadblockquiz.Bottom do
     ## see if being sued (count license issues)
     li_count =
       bottom
-      |> Enum.filter(fn block ->
+      |> Enum.count(fn block ->
         {_key, {_x, _y, color}} = block
         color == :license_grey_brown
       end)
-      |> Enum.count()
 
     ## return true if more vuln's than attack_threshold
     li_count >= suit_threshold

--- a/lib/quadblockquiz_web/live/sbom_live.ex
+++ b/lib/quadblockquiz_web/live/sbom_live.ex
@@ -15,6 +15,20 @@ defmodule QuadblockquizWeb.SbomLive do
     """
   end
 
+  #   debian.bullseye_slim-cyclonedx-bom.json
+  # debian.bullseye_slim-cyclonedx-bom.xml
+  # debian.bullseye_slim-spdx-bom.json
+  # debian.bullseye_slim-spdx-bom.spdx
+  # quadblockquiz.0.24.0-cyclonedx-sbom.1.0.0.json
+  # quadblockquiz.0.24.0-cyclonedx-sbom.1.0.0.xml
+  # quadblockquiz.0.24.0-spdx-sbom.1.0.0.spdx
+  # quadblockquiz.0.25.0-cyclonedx-sbom.1.0.0.json
+  # quadblockquiz.0.25.0-cyclonedx-sbom.1.0.0.xml
+  # quadblockquiz.0.25.0-spdx-sbom.1.0.0.spdx
+  # quadblockquiz_vex_20211214_no_log4j.html
+  # quadblockquiz_vex_20211214_no_log4j.json
+  # quadquizaminos.0.14.6-spdx-sbom.1.0.0.spdx
+
   defp sbom_files(assigns) do
     files =
       :quadblockquiz

--- a/lib/quadblockquiz_web/templates/layout/privacy_and_term_of_service.html.heex
+++ b/lib/quadblockquiz_web/templates/layout/privacy_and_term_of_service.html.heex
@@ -5,7 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= csrf_meta_tag() %>
-    <%= live_title_tag(assigns[:page_title] || "Quadblockquiz: ", suffix: " · SupplyChain Edition") %>
+    <%= live_title_tag(assigns[:page_title] || "Quadblockquiz: ",
+      suffix: " · SupplyChain Edition"
+    ) %>
     <link
       phx-track-static
       rel="stylesheet"

--- a/lib/quadblockquiz_web/templates/layout/root.html.heex
+++ b/lib/quadblockquiz_web/templates/layout/root.html.heex
@@ -5,7 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= csrf_meta_tag() %>
-    <%= live_title_tag(assigns[:page_title] || "Quadblockquiz: ", suffix: " · SupplyChain Edition") %>
+    <%= live_title_tag(assigns[:page_title] || "Quadblockquiz: ",
+      suffix: " · SupplyChain Edition"
+    ) %>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")} />
     <link
       rel="stylesheet"

--- a/lib/quadblockquiz_web/templates/layout/tailwind.html.heex
+++ b/lib/quadblockquiz_web/templates/layout/tailwind.html.heex
@@ -5,7 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= csrf_meta_tag() %>
-    <%= live_title_tag(assigns[:page_title] || "Quadblockquiz: ", suffix: " · SupplyChain Edition") %>
+    <%= live_title_tag(assigns[:page_title] || "Quadblockquiz: ",
+      suffix: " · SupplyChain Edition"
+    ) %>
     <link
       phx-track-static
       rel="stylesheet"


### PR DESCRIPTION
Why:
After upgrading Elixir and dependencies, some warnings were returned each time the CI ran linters .
These warnings were a result of :
1. Deprecated functions
2. Code not being formatted 
3. Use of IO.inspect 
4. Refactor of some implementation needed (Showing a better workaround)

https://github.com/sFractal-Podii/quizquadaminos/actions/runs/6081611458/job/16497600264