### PR TITLE
fix esbuild watch error

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,7 +16,6 @@ config :quadblockquiz, QuadblockquizWeb.Endpoint,
   watchers: [
     node: [
       "build.js",
-      "--watch",
       cd: Path.expand("../assets", __DIR__)
     ],
     npx: [


### PR DESCRIPTION
https://stackoverflow.com/questions/75221520/invalid-option-in-build-call-watch
_Better option is to use esbuild >0.16 which has a built in [live reload](https://esbuild.github.io/api/#live-reload) which combines [watch](https://esbuild.github.io/api/#watch) and [serve](https://esbuild.github.io/api/#serve) using the newly introduced [context](https://github.com/evanw/esbuild/blob/main/CHANGELOG.md#0170)_